### PR TITLE
Fix chat websocket auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Chat connection
+
+The chat system uses a WebSocket endpoint served by the local backend. When opening the WebSocket connection, the client now includes the JWT token as a `token` query parameter. The backend verifies this token before proxying the connection to the chat service.

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -69,7 +69,8 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const connectWebSocket = () => {
       try {
         const token = localStorage.getItem('jwt');
-        const wsUrl = `${window.location.origin.replace('http', 'ws')}/api/chat/ws?room=${currentRoom}`;
+        const tokenParam = token ? `&token=${encodeURIComponent(token)}` : '';
+        const wsUrl = `${window.location.origin.replace('http', 'ws')}/api/chat/ws?room=${currentRoom}${tokenParam}`;
         const ws = new WebSocket(wsUrl);
         wsRef.current = ws;
         setConnectionStatus('connecting');

--- a/src/server/chatProxy.ts
+++ b/src/server/chatProxy.ts
@@ -7,12 +7,15 @@ const router = express.Router();
 
 // Middleware: Authenticate and attach user info
 router.use('/ws', (req: express.Request, res: express.Response, next: express.NextFunction) => {
-  const token = req.headers.authorization?.split(' ')[1];
+  let token = req.headers.authorization?.split(' ')[1];
+  if (!token) {
+    token = (req.query.token as string | undefined) ?? '';
+  }
   if (!token) {
     res.status(401).send('No token');
     return;
   }
-  
+
   try {
     // Replace with your JWT secret
     const user = jwt.verify(token, process.env.JWT_SECRET || 'fallback_secret');


### PR DESCRIPTION
## Summary
- pass auth token via query param when connecting to websocket
- accept token from query params on backend
- document websocket token usage in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f9ec9d238832d9fc11609f1d10d76